### PR TITLE
Show route highlight and filter stops + various fixes, styling

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,12 +50,12 @@
     "font-awesome": "^4.7.0",
     "leaflet": "^1.0.3",
     "leaflet.vectorgrid": "^1.2.0",
-    "ngx-bootstrap": "^1.6.6",
+    "ngx-bootstrap": "^1.7.0",
     "osmtogeojson": "^3.0.0-beta.0",
     "reflect-metadata": "^0.1.10",
     "rxjs": "5.4.0",
-    "zone.js": "^0.8.11",
-    "snyk": "^1.31.0"
+    "snyk": "^1.31.0",
+    "zone.js": "^0.8.11"
   },
   "devDependencies": {
     "@angular/cli": "^1.0.4",

--- a/public_src/bootstrap.ts
+++ b/public_src/bootstrap.ts
@@ -16,7 +16,7 @@ import {HttpModule} from "@angular/http";
 import {NgModule} from "@angular/core";
 import {FormsModule}   from "@angular/forms";
 import {BrowserModule} from "@angular/platform-browser";
-import {ModalModule} from "ngx-bootstrap";
+import {AccordionModule, ModalModule} from "ngx-bootstrap";
 
 import {NgbModule} from "@ng-bootstrap/ng-bootstrap";
 
@@ -25,15 +25,21 @@ import {NavigatorComponent} from "./components/navigator/navigator.component";
 import {ToolbarComponent} from "./components/toolbar/toolbar.component";
 import {RelationBrowserComponent} from "./components/sidebar/relation-browser.component";
 import {TagBrowserComponent} from "./components/sidebar/tag-browser.component";
+import {RouteBrowserComponent} from "./components/sidebar/route-browser.component";
 import {StopBrowserComponent} from "./components/sidebar/stop-browser.component";
 import {TransporterComponent} from "./components/transporter/transporter.component";
 
 import {MapService} from "./services/map.service";
 import {GeocodingService} from "./services/geocoding.service";
 import {OverpassService} from "./services/overpass.service";
+import {StorageService} from "./services/storage.service";
+import {ProcessingService} from "./services/processing.service";
+
+import {KeysPipe} from "./components/pipes/keys.pipe";
 
 @NgModule({
-    imports: [HttpModule, FormsModule, BrowserModule, ModalModule.forRoot(), NgbModule.forRoot()],
+    imports: [AccordionModule.forRoot(), HttpModule, FormsModule, BrowserModule,
+        ModalModule.forRoot(), NgbModule.forRoot()],
     bootstrap: [AppComponent],
     declarations: [
         AppComponent,
@@ -41,13 +47,18 @@ import {OverpassService} from "./services/overpass.service";
         ToolbarComponent,
         RelationBrowserComponent,
         TagBrowserComponent,
+        RouteBrowserComponent,
         StopBrowserComponent,
-        TransporterComponent
+        TransporterComponent,
+        KeysPipe
     ],
     providers: [
         MapService,
         GeocodingService,
-        OverpassService
+        OverpassService,
+        StorageService,
+        ProcessingService,
+        KeysPipe
     ]
 })
 

--- a/public_src/components/app/app.component.html
+++ b/public_src/components/app/app.component.html
@@ -17,21 +17,38 @@
 </div>
 
 <div id="sidebar">
-    <ngb-accordion #acc="ngbAccordion" activeIds="ngb-panel-1,ngb-panel-0,ngb-panel-2">
-        <ngb-panel title="Relation browser" [disabled]="false">
-            <ng-template ngbPanelContent>
-                <relation-browser></relation-browser>
-            </ng-template>
-        </ngb-panel>
-        <ngb-panel title="Tag browser" [disabled]="false">
-            <ng-template ngbPanelContent>
-                <tag-browser></tag-browser>
-            </ng-template>
-        </ngb-panel>
-        <ngb-panel title="Stop/platform data browser" [disabled]="false">
-            <ng-template ngbPanelContent>
-                <stop-browser></stop-browser>
-            </ng-template>
-        </ngb-panel>
-    </ngb-accordion>
+    <accordion>
+        <accordion-group #a1 [isOpen]="false">
+            <div accordion-heading>
+                Relation browser
+                <i class="pull-right float-xs-right glyphicon"
+                   [ngClass]="{'glyphicon-chevron-down': a1?.isOpen, 'glyphicon-chevron-right': !a1?.isOpen}"></i>
+            </div>
+            <relation-browser></relation-browser>
+        </accordion-group>
+        <accordion-group #a2 [isOpen]="true">
+            <div accordion-heading>
+                Tag browser
+                <i class="pull-right float-xs-right glyphicon"
+                   [ngClass]="{'glyphicon-chevron-down': a2?.isOpen, 'glyphicon-chevron-right': !a2?.isOpen}"></i>
+            </div>
+            <tag-browser></tag-browser>
+        </accordion-group>
+        <accordion-group #a3 [isOpen]="true">
+            <div accordion-heading>
+                Route browser
+                <i class="pull-right float-xs-right glyphicon"
+                   [ngClass]="{'glyphicon-chevron-down': a3?.isOpen, 'glyphicon-chevron-right': !a3?.isOpen}"></i>
+            </div>
+            <route-browser></route-browser>
+        </accordion-group>
+        <accordion-group #a4 [isOpen]="true">
+            <div accordion-heading>
+                Stop/platform data browser
+                <i class="pull-right float-xs-right glyphicon"
+                   [ngClass]="{'glyphicon-chevron-down': a4?.isOpen, 'glyphicon-chevron-right': !a4?.isOpen}"></i>
+            </div>
+            <stop-browser></stop-browser>
+        </accordion-group>
+    </accordion>
 </div>

--- a/public_src/components/app/app.component.less
+++ b/public_src/components/app/app.component.less
@@ -9,7 +9,7 @@ body {
     position:absolute;
     top:50px;
     bottom:0;
-    width:70%;
+    width:65%;
 }
 
 #sidebar {
@@ -17,7 +17,7 @@ body {
     top:50px;
     bottom:0;
     right:0;
-    width:30%;
+    width:35%;
     overflow-x: hidden;
     overflow-y: scroll;
 }

--- a/public_src/components/pipes/keys.pipe.ts
+++ b/public_src/components/pipes/keys.pipe.ts
@@ -1,0 +1,12 @@
+import { PipeTransform, Pipe } from "@angular/core";
+
+@Pipe({name: "keys"})
+export class KeysPipe implements PipeTransform {
+    transform(value, args: string[]): any {
+        let keys = [];
+        for (let key in value) {
+            keys.push({ key: key, value: value[key] });
+        }
+        return keys;
+    }
+}

--- a/public_src/components/sidebar/relation-browser.component.html
+++ b/public_src/components/sidebar/relation-browser.component.html
@@ -1,1 +1,9 @@
-<p>this window should allow you to select current master relation</p>
+<div id="relation-content" class="panel panel-body panel-default">
+    <div *ngIf="!listOfRelations">
+        <h4 class="text-center text-danger">This relation has no master relation.</h4>
+        <div class="text-center">
+            <button class="btn btn-success" disabled>Create master for currently selected element</button>
+            <button class="btn btn-default" disabled>Find existing master</button>
+        </div>
+    </div>
+</div>

--- a/public_src/components/sidebar/route-browser.component.html
+++ b/public_src/components/sidebar/route-browser.component.html
@@ -1,0 +1,46 @@
+<div id="route-content" class="panel panel-body panel-default">
+
+    <div class="text-center">
+        <h4 class="text-danger"
+            *ngIf="listOfRelations.length === 0">There are no loaded routes (zoom map).</h4>
+        <h4 class="text-info"
+            *ngIf="listOfRelations.length > 0">Please select a stop/platform to browse related routes.</h4>
+        <button class="btn btn-warning" *ngIf="filteredView" (click)="cancelFilter()">Cancel filter</button>
+    </div>
+
+    <div *ngIf="listOfRelations.length !== 0 && !filteredView" class="small">
+        <table class="table-responsive table-condensed table-bordered table-hover table-striped">
+            <thead>
+                <tr>
+                    <td></td>
+                    <td title="Id">Id</td>
+                    <td title="Route">Route</td>
+                    <td title="Reference">Ref.</td>
+                    <td title="Name">Name</td>
+                    <td title="Network">Netw.</td>
+                    <td title="Operator">Oper.</td>
+                    <td title="public_transport">P_T</td>
+                    <td title="public_transport:version">P_T v.</td>
+                    <td title="Type">Type</td>
+                    <td title="Complete">Compl.</td>
+                </tr>
+            </thead>
+            <tbody #routeTableBody>
+                <tr *ngFor="let rel of listOfRelations" id="{{rel.id}}">
+                    <td class="explore" (click)="exploreRelation($event, rel)"><i class="fa fa-search" aria-hidden="true"></i></td>
+                    <td>{{rel.id}}</td>
+                    <td>{{rel.tags.route}}</td>
+                    <td>{{rel.tags.ref}}</td>
+                    <td>{{rel.tags.name}}</td>
+                    <td>{{rel.tags.network}}</td>
+                    <td>{{rel.tags.operator}}</td>
+                    <td>{{rel.tags.public_transport}}</td>
+                    <td>{{rel.tags["public_transport:version"]}}</td>
+                    <td>{{rel.tags.type}}</td>
+                    <td>{{rel.tags.complete}}</td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+
+</div>

--- a/public_src/components/sidebar/route-browser.component.less
+++ b/public_src/components/sidebar/route-browser.component.less
@@ -1,4 +1,4 @@
-#relation-content {
+#route-content {
   margin: 3px 3px 3px 3px;
   max-height: 300px;
   overflow-y: scroll;

--- a/public_src/components/sidebar/route-browser.component.ts
+++ b/public_src/components/sidebar/route-browser.component.ts
@@ -4,17 +4,18 @@ import {MapService} from "../../services/map.service";
 import {ProcessingService} from "../../services/processing.service";
 
 @Component({
-    selector: "stop-browser",
-    template: require<any>("./stop-browser.component.html"),
+    selector: "route-browser",
+    template: require<any>("./route-browser.component.html"),
     styles: [
-        require<any>("./stop-browser.component.less"),
+        require<any>("./route-browser.component.less"),
         require<any>("../../styles/main.less")
     ],
     providers: []
 })
-export class StopBrowserComponent {
-    private listOfStops: object[] = this.storageService.listOfStops;
-    public listOfStopsForRoute: object[] = this.storageService.listOfStopsForRoute;
+export class RouteBrowserComponent {
+    private listOfRelations: object[] = this.storageService.listOfRelations;
+    private listOfRelationsForStop: object[] = this.storageService.listOfRelationsForStop;
+
     private filteredView: boolean;
 
     constructor(private storageService: StorageService,
@@ -23,7 +24,7 @@ export class StopBrowserComponent {
     }
 
     ngOnInit() {
-        this.processingService.showStopsForRoute$.subscribe(
+        this.processingService.showRelationsForStop$.subscribe(
             data => {
                 this.filteredView = data;
             }
@@ -31,10 +32,12 @@ export class StopBrowserComponent {
     }
 
     private cancelFilter() {
-        this.processingService.activateFilteredStopView(false);
+        this.processingService.activateFilteredRouteView(false);
     }
 
-    private exploreStop($event, stop) {
-        this.processingService.exploreStop(stop);
+    private exploreRelation($event, rel) {
+        this.processingService.exploreRelation(rel);
     }
+
+    // listOfRelations = this.storageService.listOfRelations;
 }

--- a/public_src/components/sidebar/stop-browser.component.html
+++ b/public_src/components/sidebar/stop-browser.component.html
@@ -1,1 +1,51 @@
-<p>this window should allow you to see route's bus stops</p>
+<div id="stop-content" class="panel panel-body panel-default">
+
+    <div class="text-center">
+        <h4 class="text-danger"
+            *ngIf="listOfStops.length === 0">There are no loaded stops (zoom map).</h4>
+        <h4 class="text-info"
+            *ngIf="listOfStops.length > 0">Please select a relation to browse related stops/platforms.</h4>
+        <button class="btn btn-warning" *ngIf="filteredView" (click)="cancelFilter()">Cancel filter</button>
+    </div>
+
+    <!--{{listOfStopsForRoute | json}}-->
+
+    <div *ngIf="filteredView" class="small">
+        <table class="table-responsive table-condensed table-bordered table-hover table-striped">
+            <thead>
+            <tr>
+                <td>Role</td>
+                <td>Type</td>
+                <td>Ref</td>
+            </tr>
+            </thead>
+            <tbody>
+            <tr *ngFor="let stop of listOfStopsForRoute;">
+                <td class="explore" (click)="exploreStop($event, stop)"><i class="fa fa-search" aria-hidden="true"></i></td>
+                <td>{{stop.role}}</td>
+                <td>{{stop.type}}</td>
+                <td>{{stop.ref}}</td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+
+    <div *ngIf="listOfStops.length !== 0 && !filteredView" class="small">
+        <table class="table-responsive table-condensed table-bordered table-hover table-striped">
+            <thead>
+                <tr>
+                    <td></td>
+                    <td>Id</td>
+                    <td>Tags</td>
+                </tr>
+            </thead>
+            <tbody>
+                <tr *ngFor="let stop of listOfStops" id="{{stop.id}}">
+                    <td class="explore" (click)="exploreStop($event, stop)"><i class="fa fa-search" aria-hidden="true"></i></td>
+                    <td>{{stop.id}}</td>
+                    <td>{{stop.tags | json}}</td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+</div>

--- a/public_src/components/sidebar/stop-browser.component.less
+++ b/public_src/components/sidebar/stop-browser.component.less
@@ -1,0 +1,5 @@
+#stop-content {
+  margin: 3px 3px 3px 3px ;
+  max-height: 300px;
+  overflow-y: scroll;
+}

--- a/public_src/components/sidebar/tag-browser.component.html
+++ b/public_src/components/sidebar/tag-browser.component.html
@@ -1,1 +1,67 @@
-<p>this window should allow you to edit tags</p>
+<div id="tag-content" class="panel panel-body panel-default">
+    <h4 class="text-center text-danger" *ngIf="!elementTags">Please select a feature to browse tags.</h4>
+
+    <div *ngIf="elementTags" class="small">
+
+        <table class="table-responsive table-condensed table-bordered table-hover table-striped">
+            <thead>
+            <tr>
+                <td>Tag key</td>
+                <td>Tag value</td>
+                <td></td>
+            </tr>
+            </thead>
+            <tbody>
+            <tr *ngFor="let tag of elementTags | keys;">
+                <td>{{tag.key | json }}</td>
+                <td>{{tag.value | json }}</td>
+            </tr>
+            <tr>
+                <!--<form class="form-group form-inline col-xs-12" #formCtrl="ngForm">-->
+                <td>
+                    <input #k class="form-control" id="inputkey" type="text" [value]="tagKey"
+                           (keyup.enter)="updateKey(k.value)" (blur)="updateKey(k.value)"
+                           minlength="1" required>
+                </td>
+                <td>
+                    <input class="form-control" id="inputvalue" type="text" [value]="tagValue"
+                           #v (keyup.enter)="updateValue(v.value)" (blur)="updateValue(v.value)"
+                           minlength="1" required>
+                </td>
+                <td>
+                    <button class="btn btn-default glyphicon glyphicon-plus" aria-hidden="true"
+                            (click)="appendNewTag()" [disabled]="isUnchanged()" ></button>
+                </td>
+                <!--</form>-->
+            </tr>
+            </tbody>
+        </table>
+
+        <!--<div> Current tag and value-->
+            <!--<p>-->
+                <!--{{tagKey}}-->
+                <!--{{tagValue}}-->
+            <!--</p>-->
+            <!--<p>-->
+                <!--{{elementTags | json }}-->
+            <!--</p>-->
+        <!--</div>-->
+        <!--<div> Current changes-->
+            <!--<p>-->
+                <!--{{elementChanges | json }}-->
+            <!--</p>-->
+        <!--</div>-->
+
+        <!--<label for="inputkey">Tags</label>-->
+        <!--<form class="form-group form-inline col-xs-12" #formCtrl="ngForm">-->
+            <!--<input #k class="form-control" id="inputkey" type="text" [value]="tagKey"-->
+                   <!--(keyup.enter)="updateKey(k.value)" (blur)="updateKey(k.value)"-->
+                   <!--minlength="1" required>-->
+            <!--<input class="form-control" id="inputvalue" type="text" [value]="tagValue"-->
+                   <!--#v (keyup.enter)="updateValue(v.value)" (blur)="updateValue(v.value)"-->
+                   <!--minlength="1" required>-->
+            <!--<button class="btn btn-default glyphicon glyphicon-plus" aria-hidden="true"-->
+                    <!--(click)="appendNewTag()" [disabled]="isUnchanged"></button>-->
+        <!--</form>-->
+    </div>
+</div>

--- a/public_src/components/sidebar/tag-browser.component.less
+++ b/public_src/components/sidebar/tag-browser.component.less
@@ -1,0 +1,5 @@
+#tag-content {
+  margin: 3px 3px 3px 3px;
+  max-height: 300px;
+  overflow-y: scroll;
+}

--- a/public_src/components/sidebar/tag-browser.component.ts
+++ b/public_src/components/sidebar/tag-browser.component.ts
@@ -1,6 +1,4 @@
-import {Component} from "@angular/core";
-
-import {NgbModule} from "@ng-bootstrap/ng-bootstrap";
+import {Component, Input} from "@angular/core";
 
 @Component({
     selector: "tag-browser",
@@ -12,4 +10,26 @@ import {NgbModule} from "@ng-bootstrap/ng-bootstrap";
     providers: []
 })
 export class TagBrowserComponent {
+    private elementTags: object[] = []; // [ {"lorem": "ipsum"}, {"foo": "bar"} ]
+
+    @Input() tagKey: string = "";
+    @Input() tagValue: string = "";
+
+    private elementChanges: any = [];
+
+    constructor() { }
+
+    private updateKey(value: string) { this.tagKey = value; }
+
+    private updateValue(value: string) { this.tagValue = value; }
+
+    private appendNewTag() {
+        console.log("LOG: Added tags are: ", this.tagKey, this.tagValue);
+        this.elementTags.push( {[this.tagKey]: this.tagValue} );
+        this.tagKey = this.tagValue = "" ;
+    }
+
+    private isUnchanged() {
+        return !this.tagKey || !this.tagValue;
+    }
 }

--- a/public_src/core/ptMember.ts
+++ b/public_src/core/ptMember.ts
@@ -1,0 +1,5 @@
+export interface IPtMember {
+    type: string;
+    ref: number;
+    role: string;
+}

--- a/public_src/core/ptRelation.interface.ts
+++ b/public_src/core/ptRelation.interface.ts
@@ -1,0 +1,11 @@
+export interface IPtRelation {
+    type: number;
+    id: number;
+    timestamp: string;
+    version: number;
+    changeset: number;
+    user: string;
+    uid: number;
+    members: object[];
+    tags: object;
+}

--- a/public_src/core/ptStop.interface.ts
+++ b/public_src/core/ptStop.interface.ts
@@ -1,0 +1,12 @@
+export interface IPtStop {
+    type: string;
+    id: number;
+    lat: number;
+    lon: number;
+    timestamp: string;
+    version: number;
+    changeset: number;
+    user: string;
+    uid: number;
+    tags: object;
+}

--- a/public_src/index.html
+++ b/public_src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 
     <head>
-        <title>Angular2-Leaflet-Starter</title>
+        <title>Public Transport editor for OSM</title>
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
     </head>

--- a/public_src/services/processing.service.ts
+++ b/public_src/services/processing.service.ts
@@ -1,0 +1,130 @@
+import {Injectable} from "@angular/core";
+import {StorageService} from "./storage.service";
+import {Subject} from "rxjs/Subject";
+import {IPtStop} from "../core/ptStop.interface";
+import {IPtRelation} from "../core/ptRelation.interface";
+import {MapService} from "./map.service";
+
+@Injectable()
+export class ProcessingService {
+    // Observable boolean sources
+    private showRelationsForStopSource = new Subject<boolean>();
+    private showStopsForRouteSource = new Subject<boolean>();
+    // Observable boolean streams
+    showRelationsForStop$ = this.showRelationsForStopSource.asObservable();
+    showStopsForRoute$ = this.showStopsForRouteSource.asObservable();
+
+    constructor(private storageService: StorageService,
+                private mapService: MapService) { }
+
+    public createLists() {
+        this.storageService.localJsonStorage.elements.forEach( (element) => {
+            switch (element.type) {
+                case "node":
+                    if (element.tags && element.tags.bus === "yes") {
+                        this.storageService.listOfStops.push(element);
+                    }
+                    break;
+                case "relation":
+                    this.storageService.listOfRelations.push(element);
+                    break;
+            }
+        });
+        console.log(
+            "Total # of nodes: ", this.storageService.listOfStops.length,
+            "Total # of relations: ", this.storageService.listOfRelations.length);
+    }
+
+    // Service message commands
+    public activateFilteredRouteView(data: boolean) {
+        this.showRelationsForStopSource.next(data);
+    }
+
+    public activateFilteredStopView(data: boolean) {
+        this.showStopsForRouteSource.next(data);
+    }
+
+    public exploreRelation(rel) {
+        if (this.mapService.highlightIsActive()) this.mapService.clearHighlight();
+        this.storageService.clearRouteData();
+        if (this.mapService.showRoute(rel)) {
+            this.mapService.drawTooltipFromTo(rel);
+            this.filterStopsByRelation(rel);
+        }
+    }
+
+    public exploreStop(stop) {
+        if (this.mapService.highlightIsActive()) this.mapService.clearHighlight();
+        this.filterRelationsByStop(stop);
+    }
+    /**
+     *
+     * @param stop
+     * {
+     *    "type": "node",
+     *    "id": 447767772,
+     *    "lat": 49.6769377,
+     *    "lon": 18.3665044,
+     *    "timestamp": "2017-04-20T01:22:48Z",
+     *    "version": 3,
+     *    "changeset": 47956115,
+     *    "user": "dkocich",
+     *    "uid": 1784758,
+     *    "tags": {
+     *      "bench": "yes",
+     *      "bus": "yes",
+     *      "name": "Frýdek-Místek, Frýdek, U Gustlíčka",
+     *      "public_transport": "platform",
+     *      "shelter": "yes"
+     *    }
+     *  }
+     */
+    public filterRelationsByStop(stop: IPtStop): void {
+        this.activateFilteredRouteView(true);
+    }
+
+    /**
+     *
+     * @param rel
+     *  {
+     *    "type": "relation",
+     *    "id": 7157492,
+     *    "timestamp": "2017-05-15T22:23:20Z",
+     *    "version": 5,
+     *    "changeset": 48714598,
+     *    "user": "dkocich",
+     *    "uid": 1784758,
+     *    "members": [
+     *      {
+     *        "type": "node",
+     *        "ref": 2184049214,
+     *        "role": "stop"
+     *      },
+     *      {
+     *        "type": "node",
+     *        "ref": 2162278060,
+     *        "role": "platform"
+     *      },
+     *      {
+     *        "type": "way",
+     *        "ref": 387730713,
+     *        "role": ""
+     *      }
+     *    ],
+     *    "tags": {
+     *      "complete": "no",
+     *      "from": "Řepiště, U kříže",
+     *      "name": "Bus 11: Řepiště, U kříže -> Místek,Riviéra",
+     *      "operator": "ČSAD Frýdek-Místek",
+     *      "public_transport:version": "2",
+     *      "route": "bus",
+     *      "to": "Místek,Riviéra",
+     *      "type": "route"
+     *    }
+     *  }
+     */
+    public filterStopsByRelation(rel: IPtRelation): void {
+        this.storageService.listOfStopsForRoute = rel.members;
+        this.activateFilteredStopView(true);
+    }
+}

--- a/public_src/services/storage.service.ts
+++ b/public_src/services/storage.service.ts
@@ -1,0 +1,27 @@
+import {Injectable} from "@angular/core";
+
+@Injectable()
+export class StorageService {
+    public localJsonStorage: any;
+    public localGeojsonStorage: any;
+    public listOfStops: any = [];
+    public listOfRelations: any = [];
+
+    // filtering of sidebar
+    public listOfStopsForRoute: object[] = [];
+    public listOfRelationsForStop: object[] = [];
+
+    public stopsForRoute: object[] = [];
+    public platformsForRoute: object[] = [];
+    public waysForRoute: object[] = [];
+    public relationsForRoute: object[] = [];
+
+    public clearRouteData() {
+        this.stopsForRoute = [];
+        this.platformsForRoute = [];
+        this.waysForRoute = [];
+        this.relationsForRoute = [];
+    }
+
+    constructor() { }
+}


### PR DESCRIPTION
When user clicks on any route in the list

- [x] - the route is highlighted (connection between stops) and "from" "to" labels are created.
~~- [ ] - list of route's stops should be filtered (+ possibility for reordering later -> highlighted route should update in map)~~

![image](https://cloud.githubusercontent.com/assets/6165660/26779013/0b0a7f7c-49e4-11e7-965d-602442778f13.png)

~~When user clicks on any stop in the map~~
~~- [ ] - list of stop's (platforms) routes should be filtered~~
~~- [ ] - Maybe all filtered routes should be highlighted in map (can be expensive to calculate and draw)?~~