### PR TITLE
Filter data to see only stops/platforms (possible to change on UI)

### DIFF
--- a/public_src/bootstrap.ts
+++ b/public_src/bootstrap.ts
@@ -35,6 +35,7 @@ import {GeocodingService} from "./services/geocoding.service";
 import {OverpassService} from "./services/overpass.service";
 import {StorageService} from "./services/storage.service";
 import {ProcessingService} from "./services/processing.service";
+import {ConfigService} from "./services/config.service";
 
 import {KeysPipe} from "./components/pipes/keys.pipe";
 
@@ -60,6 +61,7 @@ import {KeysPipe} from "./components/pipes/keys.pipe";
         OverpassService,
         StorageService,
         ProcessingService,
+        ConfigService,
         KeysPipe
     ]
 })

--- a/public_src/components/toolbar/toolbar.component.html
+++ b/public_src/components/toolbar/toolbar.component.html
@@ -1,6 +1,12 @@
 <button id="toggle-download" class="btn btn-default on-map" [class.btn-primary]="downloading"
-        title="Toggle downloading of transport data" (click)="toggleDownloading()" btnCheckbox>
+        title="Toggle downloading of transport data" (click)="toggleDownloading()"
+        (mouseenter)="showOptions()" btnCheckbox>
     <i class="fa fa-repeat"></i>
+</button>
+
+<button id="toggle-filter" class="btn btn-default on-map" [class.btn-primary]="filtering"
+        title="Toggle view of routes in map" (click)="toggleLinesFilter()" btnCheckbox>
+    <i class="fa fa-filter"></i>
 </button>
 
 <transporter></transporter>

--- a/public_src/components/toolbar/toolbar.component.less
+++ b/public_src/components/toolbar/toolbar.component.less
@@ -5,6 +5,12 @@
   .map-button;
 }
 
+#toggle-filter {
+  margin: 60px 0 0 450px;
+  display: none;
+  .map-button;
+}
+
 #download-data {
   margin: 20px 0 0 490px;
   .map-button;

--- a/public_src/components/toolbar/toolbar.component.ts
+++ b/public_src/components/toolbar/toolbar.component.ts
@@ -2,6 +2,7 @@ import {Component, ViewChild} from "@angular/core";
 import {MapService} from "../../services/map.service";
 import {TransporterComponent} from "../transporter/transporter.component";
 import {OverpassService} from "../../services/overpass.service";
+import {ConfigService} from "../../services/config.service";
 
 @Component({
     selector: "toolbar",
@@ -13,16 +14,20 @@ import {OverpassService} from "../../services/overpass.service";
     providers: []
 })
 export class ToolbarComponent {
-    downloading: boolean;
+    public downloading: boolean;
+    private filtering: boolean;
 
     @ViewChild(TransporterComponent) transporterComponent: TransporterComponent;
 
-    constructor(private mapService: MapService, private overpassService: OverpassService) {
+    constructor(private mapService: MapService, private overpassService: OverpassService,
+                private configService: ConfigService) {
         this.downloading = true;
+        this.filtering = this.configService.cfgFilterLines;
     }
 
     ngOnInit() {
         this.mapService.disableMouseEvent("toggle-download");
+        this.mapService.disableMouseEvent("toggle-filter");
     }
 
     Initialize() {
@@ -55,5 +60,17 @@ export class ToolbarComponent {
                 this.initDownloader();
             });
         } else if (!this.downloading) this.mapService.map.off("zoomend moveend");
+    }
+
+    private showOptions(): void {
+        document.getElementById("toggle-filter").style.display = "inline";
+        setTimeout( function() {
+            document.getElementById("toggle-filter").style.display = "none";
+        }, 5000);
+    }
+
+    private toggleLinesFilter(): void {
+        this.configService.cfgFilterLines = !this.configService.cfgFilterLines;
+        this.filtering = !this.filtering;
     }
 }

--- a/public_src/components/transporter/transporter.component.html
+++ b/public_src/components/transporter/transporter.component.html
@@ -8,7 +8,7 @@
     <i class="fa fa-upload"></i>
 </button>
 
-<div class="modal fade" bsModal #downloadModal="bs-modal" [config]="{backdrop: 'static'}"
+<div id="modalDownload" class="modal fade" bsModal #downloadModal="bs-modal" [config]="{backdrop: 'static'}"
      tabindex="-1" role="dialog" aria-labelledby="myDownloadModalLabel" aria-hidden="true">
     <div class="modal-dialog modal-lg">
         <div class="modal-content">
@@ -44,7 +44,7 @@
     </div>
 </div>
 
-<div class="modal fade" bsModal #uploadModal="bs-modal" [config]="{backdrop: 'static'}"
+<div id="modalUpload" class="modal fade" bsModal #uploadModal="bs-modal" [config]="{backdrop: 'static'}"
      tabindex="-1" role="dialog" aria-labelledby="myUploadModalLabel" aria-hidden="true">
     <div class="modal-dialog modal-lg">
         <div class="modal-content">

--- a/public_src/components/transporter/transporter.component.ts
+++ b/public_src/components/transporter/transporter.component.ts
@@ -23,6 +23,11 @@ export class TransporterComponent {
 
     constructor(private mapService: MapService, private overpassService: OverpassService) { }
 
+    ngOnInit() {
+        this.mapService.disableMouseEvent("download-data");
+        this.mapService.disableMouseEvent("upload-data");
+    }
+
     private requestData(requestBody): void {
         this.overpassService.requestOverpassData(requestBody);
         this.hideDownloadModal();
@@ -41,6 +46,7 @@ export class TransporterComponent {
 
     public showDownloadModal(): void {
         this.downloadModal.show();
+        this.mapService.disableMouseEvent("modalDownload");
     }
 
     public hideDownloadModal(): void {
@@ -49,6 +55,7 @@ export class TransporterComponent {
 
     public showUploadModal(): void {
         this.uploadModal.show();
+        this.mapService.disableMouseEvent("modalUpload");
     }
 
     public hideUploadModal(): void {

--- a/public_src/services/config.service.ts
+++ b/public_src/services/config.service.ts
@@ -1,0 +1,6 @@
+import {Injectable} from "@angular/core";
+
+@Injectable()
+export class ConfigService {
+    public cfgFilterLines = true;
+}

--- a/public_src/services/map.service.ts
+++ b/public_src/services/map.service.ts
@@ -5,6 +5,7 @@ import {StorageService} from "./storage.service";
 import latLng = L.latLng;
 import LatLngExpression = L.LatLngExpression;
 import LatLngLiteral = L.LatLngLiteral;
+import {ConfigService} from "./config.service";
 
 const DEFAULT_ICON = L.icon({
     iconUrl: "",
@@ -61,7 +62,8 @@ export class MapService {
     private markerFrom: any = undefined;
     private markerTo: any = undefined;
 
-    constructor(private http: Http, private storageService: StorageService) {
+    constructor(private http: Http, private storageService: StorageService,
+                private configService: ConfigService) {
         this.baseMaps = {
             Empty: L.tileLayer("", {
                 attribution: ""
@@ -158,6 +160,13 @@ export class MapService {
 
     public renderTransformedGeojsonData(transformedGeojson): void {
         this.ptLayer = L.geoJSON(transformedGeojson, {
+            filter: (feature) => {
+                if (this.configService.cfgFilterLines) {
+                    return "public_transport" in feature.properties && feature.id[0] === "n";
+                } else {
+                    return true;
+                }
+            },
             pointToLayer: (feature, latlng) => {
                 return this.stylePoint(feature, latlng);
             },

--- a/public_src/services/overpass.service.ts
+++ b/public_src/services/overpass.service.ts
@@ -35,13 +35,8 @@ export class OverpassService {
         this.mapService.previousCenter = [this.mapService.map.getCenter().lat, this.mapService.map.getCenter().lng];
         this.http.post("https://overpass-api.de/api/interpreter", requestBody, options)
             .map(res => res.json())
-            .subscribe(result => {
-                console.log(result);
-                let transformedGeojson = this.mapService.osmtogeojson(result);
-                this.storageService.localJsonStorage = result;
-                this.storageService.localGeojsonStorage = transformedGeojson;
-                this.processingService.createLists();
-                this.mapService.renderTransformedGeojsonData(transformedGeojson);
+            .subscribe(response => {
+                this.processingService.processResponse(response);
             });
     }
 

--- a/public_src/services/processing.service.ts
+++ b/public_src/services/processing.service.ts
@@ -17,6 +17,15 @@ export class ProcessingService {
     constructor(private storageService: StorageService,
                 private mapService: MapService) { }
 
+    public processResponse(response) {
+        console.log(response);
+        let transformedGeojson = this.mapService.osmtogeojson(response);
+        this.storageService.localJsonStorage = response;
+        this.storageService.localGeojsonStorage = transformedGeojson;
+        this.createLists();
+        this.mapService.renderTransformedGeojsonData(transformedGeojson);
+    }
+
     public createLists() {
         this.storageService.localJsonStorage.elements.forEach( (element) => {
             switch (element.type) {


### PR DESCRIPTION
- response processing was moved from "overpass" to "processing" service
- toggle button was added to filter the rendering of ways (default ON). It is available on hover over the download button.
- disable mouse click propagation for Down/Upload buttons+modals

![image](https://user-images.githubusercontent.com/6165660/27005437-fab910cc-4e1e-11e7-8f20-fdabf55fc9ff.png)
