### PR TITLE
Show filtered route/stop data in the sidebar; browse element tags

### DIFF
--- a/public_src/components/sidebar/route-browser.component.html
+++ b/public_src/components/sidebar/route-browser.component.html
@@ -8,6 +8,41 @@
         <button class="btn btn-warning" *ngIf="filteredView" (click)="cancelFilter()">Cancel filter</button>
     </div>
 
+    <div *ngIf="listOfRelationsForStop.length !== 0 && filteredView" class="small">
+        <table class="table-responsive table-condensed table-bordered table-hover table-striped">
+            <thead>
+            <tr>
+                <td></td>
+                <td title="Id">Id</td>
+                <td title="Route">Route</td>
+                <td title="Reference">Ref.</td>
+                <td title="Name">Name</td>
+                <td title="Network">Netw.</td>
+                <td title="Operator">Oper.</td>
+                <td title="public_transport">P_T</td>
+                <td title="public_transport:version">P_T v.</td>
+                <td title="Type">Type</td>
+                <td title="Complete">Compl.</td>
+            </tr>
+            </thead>
+            <tbody #routeTableBody>
+            <tr *ngFor="let rel of listOfRelationsForStop">
+                <td class="explore" (click)="exploreRelation($event, rel)"><i class="fa fa-search" aria-hidden="true"></i></td>
+                <td>{{rel.id}}</td>
+                <td>{{rel.tags.route}}</td>
+                <td>{{rel.tags.ref}}</td>
+                <td>{{rel.tags.name}}</td>
+                <td>{{rel.tags.network}}</td>
+                <td>{{rel.tags.operator}}</td>
+                <td>{{rel.tags.public_transport}}</td>
+                <td>{{rel.tags["public_transport:version"]}}</td>
+                <td>{{rel.tags.type}}</td>
+                <td>{{rel.tags.complete}}</td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+
     <div *ngIf="listOfRelations.length !== 0 && !filteredView" class="small">
         <table class="table-responsive table-condensed table-bordered table-hover table-striped">
             <thead>

--- a/public_src/components/sidebar/route-browser.component.ts
+++ b/public_src/components/sidebar/route-browser.component.ts
@@ -29,6 +29,13 @@ export class RouteBrowserComponent {
                 this.filteredView = data;
             }
         );
+        this.processingService.refreshSidebarViews$.subscribe(
+            data => {
+                if (data === "route") {
+                    this.listOfRelationsForStop = this.storageService.listOfRelationsForStop;
+                }
+            }
+        );
     }
 
     private cancelFilter() {

--- a/public_src/components/sidebar/stop-browser.component.html
+++ b/public_src/components/sidebar/stop-browser.component.html
@@ -14,6 +14,7 @@
         <table class="table-responsive table-condensed table-bordered table-hover table-striped">
             <thead>
             <tr>
+                <td></td>
                 <td>Role</td>
                 <td>Type</td>
                 <td>Ref</td>

--- a/public_src/components/sidebar/stop-browser.component.ts
+++ b/public_src/components/sidebar/stop-browser.component.ts
@@ -28,6 +28,13 @@ export class StopBrowserComponent {
                 this.filteredView = data;
             }
         );
+        this.processingService.refreshSidebarViews$.subscribe(
+            data => {
+                if (data === "stop") {
+                    this.listOfStopsForRoute = this.storageService.listOfStopsForRoute;
+                }
+            }
+        );
     }
 
     private cancelFilter() {

--- a/public_src/components/sidebar/tag-browser.component.html
+++ b/public_src/components/sidebar/tag-browser.component.html
@@ -13,8 +13,8 @@
             </thead>
             <tbody>
             <tr *ngFor="let tag of elementTags | keys;">
-                <td>{{tag.key | json }}</td>
-                <td>{{tag.value | json }}</td>
+                <td>{{tag.key }}</td>
+                <td>{{tag.value }}</td>
             </tr>
             <tr>
                 <!--<form class="form-group form-inline col-xs-12" #formCtrl="ngForm">-->

--- a/public_src/components/sidebar/tag-browser.component.ts
+++ b/public_src/components/sidebar/tag-browser.component.ts
@@ -1,4 +1,6 @@
 import {Component, Input} from "@angular/core";
+import {ProcessingService} from "../../services/processing.service";
+import {StorageService} from "../../services/storage.service";
 
 @Component({
     selector: "tag-browser",
@@ -10,14 +12,25 @@ import {Component, Input} from "@angular/core";
     providers: []
 })
 export class TagBrowserComponent {
-    private elementTags: object[] = []; // [ {"lorem": "ipsum"}, {"foo": "bar"} ]
+    private elementTags: object;
 
     @Input() tagKey: string = "";
     @Input() tagValue: string = "";
 
     private elementChanges: any = [];
 
-    constructor() { }
+    constructor(private processingService: ProcessingService,
+                private storageService: StorageService) { }
+
+    ngOnInit() {
+        this.processingService.refreshSidebarViews$.subscribe(
+            data => {
+                if (data === "tag") {
+                    this.elementTags = this.storageService.currentElement;
+                }
+            }
+        );
+    }
 
     private updateKey(value: string) { this.tagKey = value; }
 
@@ -25,7 +38,7 @@ export class TagBrowserComponent {
 
     private appendNewTag() {
         console.log("LOG: Added tags are: ", this.tagKey, this.tagValue);
-        this.elementTags.push( {[this.tagKey]: this.tagValue} );
+        this.elementTags[this.tagKey] = this.tagValue;
         this.tagKey = this.tagValue = "" ;
     }
 

--- a/public_src/services/storage.service.ts
+++ b/public_src/services/storage.service.ts
@@ -1,12 +1,13 @@
 import {Injectable} from "@angular/core";
+import {IPtStop} from "../core/ptStop.interface";
 
 @Injectable()
 export class StorageService {
     public localJsonStorage: any;
-    public localGeojsonStorage: any;
-    public listOfStops: any = [];
-    public listOfRelations: any = [];
-    public listOfMasters: any = [];
+    public localGeojsonStorage: object;
+    public listOfStops: IPtStop[] = [];
+    public listOfRelations: object[] = [];
+    public listOfMasters: object[] = [];
 
     // filtering of sidebar
     public listOfStopsForRoute: object[] = [];
@@ -16,6 +17,7 @@ export class StorageService {
     public platformsForRoute: object[] = [];
     public waysForRoute: object[] = [];
     public relationsForRoute: object[] = [];
+    public currentElement: object = {};
 
     public displayName: string = "";
 


### PR DESCRIPTION
Show filtered route/stop data in the sidebar; browse element tags  …
- filtered view on sidebar's routes/stops is visible now
- it is possible to see listed tags of any element
- all this was done with implementation of shared Subject<string> (processing service) which passes refresh requests to different components
- for tag, I have to store currently selected element (storage service) across different components