### PR TITLE
Add zoom levels with stretched basemap tiles

### DIFF
--- a/public_src/components/app/app.component.ts
+++ b/public_src/components/app/app.component.ts
@@ -44,7 +44,7 @@ export class AppComponent {
             center: L.latLng(49.686, 18.351),
             zoom: 14,
             minZoom: 4,
-            maxZoom: 19,
+            maxZoom: 22,
             layers: [this.mapService.baseMaps.CartoDB]
         });
 

--- a/public_src/services/map.service.ts
+++ b/public_src/services/map.service.ts
@@ -72,15 +72,19 @@ export class MapService {
                 attribution: ""
             }),
             OpenStreetMap: L.tileLayer("https://{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png", {
+                maxNativeZoom: 19, maxZoom: 22,
                 attribution: "&copy; <a href='https://www.openstreetmap.org/copyright'>OpenStreetMap</a>, Tiles courtesy of <a href='https://hot.openstreetmap.org/' target='_blank'>Humanitarian OpenStreetMap Team</a>"
             }),
             Esri: L.tileLayer("https://server.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/{z}/{y}/{x}", {
+                maxNativeZoom: 19, maxZoom: 22,
                 attribution: "Tiles &copy; Esri &mdash; Esri, DeLorme, NAVTEQ, TomTom, Intermap, iPC, USGS, FAO, NPS, NRCAN, GeoBase, Kadaster NL, Ordnance Survey, Esri Japan, METI, Esri China (Hong Kong), and the GIS User Community"
             }),
             CartoDB: L.tileLayer("http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png", {
+                maxNativeZoom: 19, maxZoom: 22,
                 attribution: "&copy; <a href='http://www.openstreetmap.org/copyright'>OpenStreetMap</a> &copy; <a href='https://cartodb.com/attributions'>CartoDB</a>"
             }),
             EsriImagery: L.tileLayer("https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}", {
+                maxNativeZoom: 19, maxZoom: 22,
                 attribution: "&copy; ESRI https://leaflet-extras.github.io/leaflet-providers/preview/"
                 })
         };


### PR DESCRIPTION
It was required to set [maxNativeZoom](http://leafletjs.com/reference-1.0.3.html#tilelayer-maxnativezoom) for layers.

Fix https://github.com/dkocich/osm-pt-ngx-leaflet/issues/53