### PR TITLE
Fixup - filtering works now when stop browser shows only filtered list

### DIFF
--- a/public_src/services/processing.service.ts
+++ b/public_src/services/processing.service.ts
@@ -26,6 +26,7 @@ export class ProcessingService {
         this.mapService.bounds = this.mapService.map.getBounds();
         for (let stop of this.storageService.listOfStops) {
             let el = document.getElementById(stop.id.toString());
+            if (!el) return;
             if (el && this.mapService.bounds.contains([stop.lat, stop.lon])) {
                 el.style.display = "table-row";
             } else {


### PR DESCRIPTION
There was a problem with the hiding of invisible stops while filtering view was active.