### PR TITLE
Change route table view to rows in the sidebar

### DIFF
--- a/public_src/components/sidebar/route-browser.component.html
+++ b/public_src/components/sidebar/route-browser.component.html
@@ -7,73 +7,17 @@
     </div>
 
     <div *ngIf="listOfRelationsForStop.length !== 0 && filteredView" class="small">
-        <table class="table-responsive table-condensed table-bordered table-hover table-striped">
-            <thead>
-            <tr>
-                <td></td>
-                <td title="Id"><b>Id</b></td>
-                <td title="Route"><b>Route</b></td>
-                <td title="Reference"><b>Ref.</b></td>
-                <td title="Name"><b>Name</b></td>
-                <td title="Network"><b>Netw.</b></td>
-                <td title="Operator"><b>Oper.</b></td>
-                <td title="public_transport"><b>P_T</b></td>
-                <td title="public_transport:version"><b>P_T v.</b></td>
-                <td title="Type"><b>Type</b></td>
-                <td title="Complete"><b>Compl.</b></td>
-            </tr>
-            </thead>
-            <tbody #routeTableBody>
-            <tr *ngFor="let rel of listOfRelationsForStop">
-                <td class="explore" (click)="exploreRelation($event, rel)"><i class="fa fa-search" aria-hidden="true"></i></td>
-                <td>{{rel.id}}</td>
-                <td>{{rel.tags.route}}</td>
-                <td>{{rel.tags.ref}}</td>
-                <td>{{rel.tags.name}}</td>
-                <td>{{rel.tags.network}}</td>
-                <td>{{rel.tags.operator}}</td>
-                <td>{{rel.tags.public_transport}}</td>
-                <td>{{rel.tags["public_transport:version"]}}</td>
-                <td>{{rel.tags.type}}</td>
-                <td>{{rel.tags.complete}}</td>
-            </tr>
-            </tbody>
-        </table>
+        <div *ngFor="let rel of listOfRelationsForStop">
+            <span class="explore" (click)="exploreRelation($event, rel)"><i class="fa fa-search" aria-hidden="true"></i></span>
+            <span>{{rel.tags.route || "#TYPE" }} Route {{rel.tags.ref || "#REF"}}: {{rel.tags.from || "#FROM"}} => {{rel.tags.to || "#TO"}}, {{rel.tags.name || "#NAME"}}</span>
+        </div>
     </div>
 
     <div *ngIf="listOfRelations.length !== 0 && !filteredView" class="small">
-        <table class="table-responsive table-condensed table-bordered table-hover table-striped">
-            <thead>
-                <tr>
-                    <td></td>
-                    <td title="Id"><b>Id</b></td>
-                    <td title="Route"><b>Route</b></td>
-                    <td title="Reference"><b>Ref.</b></td>
-                    <td title="Name"><b>Name</b></td>
-                    <td title="Network"><b>Netw.</b></td>
-                    <td title="Operator"><b>Oper.</b></td>
-                    <td title="public_transport"><b>P_T</b></td>
-                    <td title="public_transport:version"><b>P_T v.</b></td>
-                    <td title="Type"><b>Type</b></td>
-                    <td title="Complete"><b>Compl.</b></td>
-                </tr>
-            </thead>
-            <tbody #routeTableBody>
-                <tr *ngFor="let rel of listOfRelations" id="{{rel.id}}">
-                    <td class="explore" (click)="exploreRelation($event, rel)"><i class="fa fa-search" aria-hidden="true"></i></td>
-                    <td>{{rel.id}}</td>
-                    <td>{{rel.tags.route}}</td>
-                    <td>{{rel.tags.ref}}</td>
-                    <td>{{rel.tags.name}}</td>
-                    <td>{{rel.tags.network}}</td>
-                    <td>{{rel.tags.operator}}</td>
-                    <td>{{rel.tags.public_transport}}</td>
-                    <td>{{rel.tags["public_transport:version"]}}</td>
-                    <td>{{rel.tags.type}}</td>
-                    <td>{{rel.tags.complete}}</td>
-                </tr>
-            </tbody>
-        </table>
+        <div *ngFor="let rel of listOfRelations" id="{{rel.id}}">
+            <span class="explore" (click)="exploreRelation($event, rel)"><i class="fa fa-search" aria-hidden="true"></i></span>
+            <span>{{rel.tags.route || "#TYPE" }} Route {{rel.tags.ref || "#REF"}}: {{rel.tags.from || "#FROM"}} => {{rel.tags.to || "#TO"}}, {{rel.tags.name || "#NAME"}}</span>
+        </div>
     </div>
 
 </div>

--- a/public_src/services/processing.service.ts
+++ b/public_src/services/processing.service.ts
@@ -156,9 +156,9 @@ export class ProcessingService {
         if (this.mapService.showRoute(rel)) {
             this.mapService.drawTooltipFromTo(rel);
             this.filterStopsByRelation(rel);
-            this.refreshTagView(rel.tags);
             this.mapService.map.fitBounds(this.mapService.highlightStroke.getBounds());
         }
+        this.refreshTagView(rel.tags);
     }
 
     /**

--- a/public_src/styles/main.less
+++ b/public_src/styles/main.less
@@ -20,7 +20,8 @@
 }
 
 .content {
+  white-space: nowrap;
   overflow-y: scroll;
-  min-height: 15vh;
-  max-height: 300px;
+  min-height: 20vh;
+  max-height: 350px;
 }


### PR DESCRIPTION
Lines are not wrapped, they are scrollable to the right to fit vertically as much data as possible.
![image](https://user-images.githubusercontent.com/6165660/27551569-3a3b5674-5aa4-11e7-9716-54c6dfa93d9f.png)
