### PR TITLE
Load and zoom current selection in JOSM

### DIFF
--- a/public_src/components/toolbar/toolbar.component.html
+++ b/public_src/components/toolbar/toolbar.component.html
@@ -38,4 +38,8 @@
         <i class="fa fa-times" aria-hidden="true"></i> Cancel </span>
     <span tooltip="Show more information" container="body" class="explore" (click)="showInfo(currentElement)">
         <i class="fa fa-question-circle" aria-hidden="true"></i> Info </span>
+    <button type="button" class="btn btn-default" (click)="getLoadAndZoomUrl()" [disabled]="isDisabled()"
+            tooltip="Open current element in JOSM" container="body">
+        <i class="fa fa-download" aria-hidden="true"></i> Open in JOSM
+    </button>
 </div>

--- a/public_src/components/toolbar/toolbar.component.ts
+++ b/public_src/components/toolbar/toolbar.component.ts
@@ -136,4 +136,16 @@ export class ToolbarComponent {
     private clearHighlight(): void {
         return this.mapService.clearHighlight();
     }
+
+    private getLoadAndZoomUrl(): void {
+        window.location.href = "http://127.0.0.1:8111/load_and_zoom?left=" + this.mapService.map.getBounds().getWest() +
+            "&right=" + this.mapService.map.getBounds().getEast() +
+            "&top=" + this.mapService.map.getBounds().getNorth() +
+            "&bottom=" + this.mapService.map.getBounds().getSouth() +
+            "&select=" + this.currentElement.type + this.currentElement.id;
+    }
+
+    private isDisabled(): boolean {
+        return this.currentElement.id < 0;
+    }
 }


### PR DESCRIPTION
related to https://github.com/dkocich/osm-pt-ngx-leaflet/issues/117

A button is added to the window with the current selection. It takes one object now without applying any created edits.