### PR TITLE
Show only routes which are inside map view

### DIFF
--- a/public_src/components/sidebar/route-browser.component.html
+++ b/public_src/components/sidebar/route-browser.component.html
@@ -43,7 +43,7 @@
         </ng-container>
         <ng-container *ngFor="let rel of listOfRelations">
             <ng-container *ngIf="!hasMaster(rel.id)">
-                <div id="{{rel.id}}">
+                <div id="{{rel.id}}" *ngIf="visibleInMap(rel.id)">
                     <span class="explore" (click)="exploreRelation($event, rel)" [class.selected]="currentElement && isSelected(rel.id)">
                         <span *ngIf="rel.id < 0">
                             <i *ngIf="!hasMaster(rel.id)" class="fa fa-times-circle" aria-hidden="true"

--- a/public_src/components/sidebar/route-browser.component.ts
+++ b/public_src/components/sidebar/route-browser.component.ts
@@ -126,4 +126,23 @@ export class RouteBrowserComponent {
     private isSelected(relId: number): boolean {
         return this.processingService.haveSameIds(relId, this.currentElement.id);
     }
+
+    private visibleInMap(relId: any): boolean {
+        const rel = this.storageService.elementsMap.get(relId);
+        if (rel.members.length === 0) {
+            return true; // empty routes are always visible
+        }
+        for (const member of rel.members) {
+            if (["platform", "stop_position"].indexOf(member.role) > -1) {
+                if (this.storageService.elementsMap.has(member.ref)) {
+                    const element = this.storageService.elementsMap.get(member.ref);
+                    if (this.mapService.map.getBounds().contains({
+                            lat: element .lat, lng: element .lon })) {
+                        return true; // return true while at least first node is visible
+                    }
+                }
+            }
+        }
+        return false;
+    }
 }


### PR DESCRIPTION
Routes in the sidebar are filtered depending if they are (not) visible in the map view.