### PR TITLE
Hide alert when only route platforms are available and highlight route

### DIFF
--- a/public_src/components/toolbar/toolbar.component.html
+++ b/public_src/components/toolbar/toolbar.component.html
@@ -13,9 +13,9 @@
 
 <div id="radio-highlight" *ngIf="highlightIsActive() && isRelation()">
     <div class="btn-group">
-        <label class="btn btn-primary" [(ngModel)]="htRadioModel" (click)="changeHighlight()"
+        <label class="btn btn-primary" [(ngModel)]="htRadioModel" (click)="changeHighlight()" [ngClass]="{'text-uppercase': htRadioModel === 'Stops'}"
                tooltip="Highlight connectivity between route's stops" container="body" btnRadio="Stops">Stops</label>
-        <label class="btn btn-primary" [(ngModel)]="htRadioModel" (click)="changeHighlight()"
+        <label class="btn btn-primary" [(ngModel)]="htRadioModel" (click)="changeHighlight()" [ngClass]="{'text-uppercase': htRadioModel === 'Platforms'}"
                tooltip="Highlight connectivity between route's platforms" container="body" btnRadio="Platforms">Platforms</label>
     </div>
 </div>

--- a/public_src/components/toolbar/toolbar.component.ts
+++ b/public_src/components/toolbar/toolbar.component.ts
@@ -22,7 +22,7 @@ import { IOsmEntity } from "../../core/osmEntity.interface";
 })
 export class ToolbarComponent {
     public downloading: boolean;
-    public htRadioModel: string = "Stops";
+    public htRadioModel: string;
     @ViewChild(TransporterComponent) public transporterComponent: TransporterComponent;
     @ViewChild(EditorComponent) public editorComponent: EditorComponent;
     private filtering: boolean;
@@ -45,6 +45,9 @@ export class ToolbarComponent {
             }
         );
         this.storageService.stats.subscribe((data) => this.stats = data);
+        this.mapService.highlightTypeEmitter.subscribe((data) => {
+            this.htRadioModel = data.highlightType;
+        });
     }
 
     ngOnInit(): void {
@@ -63,7 +66,6 @@ export class ToolbarComponent {
     }
 
     private changeHighlight(): void {
-        console.log(this.htRadioModel);
         if (this.highlightIsActive() && this.htRadioModel !== this.mapService.highlightType) {
             this.mapService.highlightType = this.htRadioModel;
             this.processingService.exploreRelation(


### PR DESCRIPTION
- separate function to highlight and label first&last node (stop/platform) to reflect changing of highlighting type mode
- add upperCase text to currently highlighted mode (stops/platforms) to make it more obvious
- append info to from/to label that they are labeled by tags (not currently highlighted node)