### PR TITLE
fix: serve CartoDB tiles over HTTPS (#169) [ci-skip]

### DIFF
--- a/public_src/services/map.service.ts
+++ b/public_src/services/map.service.ts
@@ -84,7 +84,7 @@ export class MapService {
         attribution: "",
       }),
       CartoDB_dark: L.tileLayer(
-        "http://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png",
+        "https://cartodb-basemaps-{s}.global.ssl.fastly.net/dark_all/{z}/{x}/{y}.png",
         {
           attribution: `&copy; <a href='http://www.openstreetmap.org/copyright'>OpenStreetMap
             </a> &copy; <a href='https://cartodb.com/attributions'>CartoDB</a>`,
@@ -93,7 +93,7 @@ export class MapService {
         },
       ),
       CartoDB_light: L.tileLayer(
-        "http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png",
+        "https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png",
         {
           attribution: `&copy; <a href='http://www.openstreetmap.org/copyright'>OpenStreetMap
             </a> &copy; <a href='https://cartodb.com/attributions'>CartoDB</a>`,


### PR DESCRIPTION
  Fix #169 