### PR TITLE
refactor: deprecated ng/http to ng/common/HttpClient; fixes -read detail

### DIFF
--- a/public_src/components/app/app.component.ts
+++ b/public_src/components/app/app.component.ts
@@ -1,8 +1,12 @@
 import { Component, isDevMode, ViewChild } from '@angular/core';
+import { NgRedux, select } from '@angular-redux/store';
 import { CarouselConfig, ModalDirective } from 'ngx-bootstrap';
 
 import * as L from 'leaflet';
 
+import { Observable } from 'rxjs/Observable';
+
+import { EditService } from '../../services/edit.service';
 import { GeocodeService } from '../../services/geocode.service';
 import { LoadService } from '../../services/load.service';
 import { MapService } from '../../services/map.service';
@@ -10,11 +14,8 @@ import { ProcessService } from '../../services/process.service';
 
 import { AuthComponent } from '../auth/auth.component';
 import { ToolbarComponent } from '../toolbar/toolbar.component';
-import { EditService } from '../../services/edit.service';
 
 import { IAppState } from '../../store/model';
-import { NgRedux, select } from '@angular-redux/store';
-import { Observable } from 'rxjs/Observable';
 
 @Component({
   providers: [{ provide: CarouselConfig, useValue: { noPause: false } }],
@@ -71,12 +72,7 @@ export class AppComponent {
     ) {
       this.mapSrv.zoomToHashedPosition();
     } else {
-      this.geocodeSrv
-        .getCurrentLocation()
-        .subscribe(
-          (location) => map.panTo([location.latitude, location.longitude]),
-          (err) => console.error(err),
-        );
+      this.geocodeSrv.getCurrentLocation();
     }
     this.toolbarComponent.Initialize();
   }

--- a/public_src/components/navigator/navigator.component.ts
+++ b/public_src/components/navigator/navigator.component.ts
@@ -1,5 +1,7 @@
 import { Component } from '@angular/core';
+
 import { Map } from 'leaflet';
+
 import { GeocodeService } from '../../services/geocode.service';
 import { MapService } from '../../services/map.service';
 
@@ -34,13 +36,6 @@ export class NavigatorComponent {
     if (!this.address) {
       return;
     }
-
-    this.geocodeSrv.geocode(this.address).subscribe(
-      (location) => {
-        this.map.fitBounds(location.viewBounds, {});
-        this.address = location.address;
-      },
-      (error) => console.error(error),
-    );
+    this.geocodeSrv.geocode(this.address);
   }
 }

--- a/public_src/components/sidebar/tag-browser.component.ts
+++ b/public_src/components/sidebar/tag-browser.component.ts
@@ -4,15 +4,16 @@ import {
   Component,
   Input,
 } from '@angular/core';
+import { select } from '@angular-redux/store';
+
+import { Observable } from 'rxjs/Observable';
 
 import { EditService } from '../../services/edit.service';
 import { ProcessService } from '../../services/process.service';
 import { StorageService } from '../../services/storage.service';
 
-import { IOsmEntity } from '../../core/osmEntity.interface';
+import { IOsmElement } from '../../core/osmElement.interface';
 
-import { select } from '@angular-redux/store';
-import { Observable } from 'rxjs/Observable';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.Default,
@@ -27,7 +28,7 @@ import { Observable } from 'rxjs/Observable';
 export class TagBrowserComponent {
   @Input() public tagKey: string = '';
   @Input() public tagValue: string = '';
-  public currentElement: IOsmEntity;
+  public currentElement: IOsmElement;
   @select(['app', 'editing']) public readonly editing$: Observable<boolean>;
 
   public expectedKeys = [

--- a/public_src/components/toolbar/toolbar.component.ts
+++ b/public_src/components/toolbar/toolbar.component.ts
@@ -9,7 +9,7 @@ import { OverpassService } from '../../services/overpass.service';
 import { ProcessService } from '../../services/process.service';
 import { StorageService } from '../../services/storage.service';
 
-import { IOsmEntity } from '../../core/osmEntity.interface';
+import { IOsmElement } from '../../core/osmElement.interface';
 
 @Component({
   providers: [],
@@ -28,7 +28,7 @@ export class ToolbarComponent {
   @ViewChild(EditorComponent) public editorComponent: EditorComponent;
   public filtering: boolean;
 
-  public currentElement: IOsmEntity;
+  public currentElement: IOsmElement;
   public stats = { s: 0, r: 0, a: 0, m: 0 };
 
   constructor(
@@ -151,7 +151,7 @@ export class ToolbarComponent {
     this.processSrv.cancelSelection();
   }
 
-  private zoomTo(selection: IOsmEntity): void {
+  private zoomTo(selection: IOsmElement): void {
     this.processSrv.zoomToElement(selection);
   }
 

--- a/public_src/core/osmElement.interface.ts
+++ b/public_src/core/osmElement.interface.ts
@@ -1,4 +1,4 @@
-export interface IOsmEntity {
+export interface IOsmElement {
   type: string;
   id: number;
   timestamp: string;

--- a/public_src/core/overpassResponse.interface.ts
+++ b/public_src/core/overpassResponse.interface.ts
@@ -1,0 +1,12 @@
+import { IOsmElement } from './osmElement.interface';
+
+export interface IOverpassResponse extends Response {
+  elements: [ IOsmElement ];
+  generator: string; // "Overpass API 0.7.55 579b1eec"
+  osm3s: {
+    copyright: string, // "The data included in this document is from www.openstreetmap.org.
+                       // The data is made available under ODbL."
+    timestamp_osm_base: string, // date string - "2018-05-02T19:51:03Z"
+  };
+  version: number; // 0.6
+}

--- a/public_src/core/ptRelation.interface.ts
+++ b/public_src/core/ptRelation.interface.ts
@@ -1,6 +1,7 @@
-import { IOsmEntity } from './osmEntity.interface';
+import { IOsmElement } from './osmElement.interface';
 import { IPtMember } from './ptMember';
 import { IOsmTags } from './osmTags.interface';
+
 /**
  *  {
  *    "type": "relation",
@@ -39,7 +40,7 @@ import { IOsmTags } from './osmTags.interface';
  *    }
  *  }
  */
-export interface IPtRelation extends IOsmEntity {
+export interface IPtRelation extends IOsmElement {
   type: 'relation';
   members: IPtMember[];
   tags: IOsmTags;

--- a/public_src/core/ptRelationNew.interface.ts
+++ b/public_src/core/ptRelationNew.interface.ts
@@ -1,6 +1,7 @@
-import { IOsmEntity } from './osmEntity.interface';
+import { IOsmElement } from './osmElement.interface';
 import { IPtMember } from './ptMember';
-export interface IPtRelationNew extends IOsmEntity {
+
+export interface IPtRelationNew extends IOsmElement {
   type: 'relation';
   members: IPtMember[];
   tags: {

--- a/public_src/core/ptRouteMasterNew.interface.ts
+++ b/public_src/core/ptRouteMasterNew.interface.ts
@@ -1,6 +1,7 @@
-import { IOsmEntity } from './osmEntity.interface';
+import { IOsmElement } from './osmElement.interface';
 import { IPtMember } from './ptMember';
-export interface IPtRouteMasterNew extends IOsmEntity {
+
+export interface IPtRouteMasterNew extends IOsmElement {
   type: 'relation';
   members: IPtMember[];
   tags: {

--- a/public_src/core/ptStop.interface.ts
+++ b/public_src/core/ptStop.interface.ts
@@ -1,4 +1,5 @@
-import { IOsmEntity } from './osmEntity.interface';
+import { IOsmElement } from './osmElement.interface';
+
 /**
  * {
  *    "type": "node",
@@ -19,7 +20,7 @@ import { IOsmEntity } from './osmEntity.interface';
  *    }
  *  }
  */
-export interface IPtStop extends IOsmEntity {
+export interface IPtStop extends IOsmElement {
   lat: number;
   lon: number;
 }

--- a/public_src/core/responses.interface.ts
+++ b/public_src/core/responses.interface.ts
@@ -1,0 +1,61 @@
+export interface IResponseIp {
+  ip: string;
+}
+
+/**
+ * TODO
+ * deprecation message in the response:
+ *
+ * "This API endpoint is deprecated and will stop working on July 1st, 2018.
+ * For more information please visit: https://github.com/apilayer/freegeoip#readme"
+ */
+export interface IResponseFreeGeoIp {
+  city: string;
+  country_code: string;
+  country_name: string;
+  ip: string;
+  latitude: number;
+  longitude: number;
+  metro_code: number;
+  region_code: string;
+  region_name: string;
+  time_zone: string;
+  zip_code: string;
+  __deprecation_message__: string;
+}
+
+export interface IResponseGeocodeGMaps {
+  error_message?: string;
+  results: [ IGeocodeResultGMaps ];
+  status: string; // "OVER_QUERY_LIMIT" / "OK" / ...
+}
+
+export interface IGeocodeResultGMaps {
+  address_components: IAddressComponentGMaps[];
+  formatted_address: string;
+  geometry: IGeometryGMaps;
+  place_id: string;
+  types: string[]; // "locality", "political",...
+}
+export interface IAddressComponentGMaps {
+  long_name: string;
+  short_name: string;
+  types: string[]; // "locality", "political",...
+}
+
+export interface IGeometryGMaps {
+  bounds: IViewportGMaps;
+  location: ILatLngGMaps;
+  location_type: string; // "APPROXIMATE",...
+  viewport: IViewportGMaps;
+}
+
+export interface IViewportGMaps {
+  southwest: ILatLngGMaps;
+  northeast: ILatLngGMaps;
+}
+
+export interface ILatLngGMaps {
+  lat: number;
+  lng: number;
+}

--- a/public_src/services/geocode.service.ts
+++ b/public_src/services/geocode.service.ts
@@ -1,74 +1,80 @@
 import { Injectable } from '@angular/core';
-import { Http, Response } from '@angular/http';
-import { Location } from '../core/location.class';
-
-import 'rxjs/add/operator/map';
-import 'rxjs/add/operator/mergeMap';
+import { HttpClient } from '@angular/common/http';
 
 import * as L from 'leaflet';
+import {
+  IResponseFreeGeoIp,
+  IResponseGeocodeGMaps,
+  IResponseIp,
+} from '../core/responses.interface';
+import { Location } from '../core/location.class';
+
+import { MapService } from './map.service';
 
 @Injectable()
 export class GeocodeService {
-  public http: Http;
+  public httpClient: HttpClient;
 
-  constructor(http: Http) {
-    this.http = http;
+  constructor(
+    httpClient: HttpClient,
+    private mapSrv: MapService,
+  ) {
+    this.httpClient = httpClient;
   }
 
   public geocode(address: string): any {
-    return this.http
-      .get(
-        'https://maps.googleapis.com/maps/api/geocode/json?address=' +
-          encodeURIComponent(address),
-      )
-      .map((res) => res.json())
-      .map((result) => {
-        if (result.status !== 'OK') {
-          throw new Error('unable to geocode address');
-        }
-
-        const location = new Location();
-        location.address = result.results[0].formatted_address;
-        location.latitude = result.results[0].geometry.location.lat;
-        location.longitude = result.results[0].geometry.location.lng;
-
-        const viewPort = result.results[0].geometry.viewport;
-        location.viewBounds = L.latLngBounds(
-          {
-            lat: viewPort.southwest.lat,
-            lng: viewPort.southwest.lng,
-          },
-          {
-            lat: viewPort.northeast.lat,
-            lng: viewPort.northeast.lng,
-          },
-        );
-
-        return location;
-      });
+    return this.httpClient.get<IResponseGeocodeGMaps>(
+        `https://maps.googleapis.com/maps/api/geocode/json?address=${encodeURIComponent(address)}`)
+      .subscribe(
+        (response: IResponseGeocodeGMaps) => {
+          if (response.status !== 'OK') {
+            throw new Error(`${response.status}; ${response.error_message}`);
+          }
+          const location = new Location();
+          location.address = response.results[0].formatted_address;
+          location.latitude = response.results[0].geometry.location.lat;
+          location.longitude = response.results[0].geometry.location.lng;
+          const viewPort = response.results[0].geometry.viewport;
+          location.viewBounds = L.latLngBounds(
+            {
+              lat: viewPort.southwest.lat,
+              lng: viewPort.southwest.lng,
+            },
+            {
+              lat: viewPort.northeast.lat,
+              lng: viewPort.northeast.lng,
+            },
+          );
+          this.mapSrv.map.fitBounds(location.viewBounds, {});
+        },
+        (error) => {
+          throw new Error(error);
+        },
+      );
   }
 
   public getCurrentLocation(): any {
-    return this.http
-      .get('https://ipv4.myexternalip.com/json')
-      .map((res) => res.json().ip)
-      .flatMap((ip) => this.http.get('https://freegeoip.net/json/' + ip))
-      .map((res: Response) => res.json())
-      .map((result) => {
-        const location = new Location();
-
-        location.address =
-          result.city +
-          ', ' +
-          result.region_code +
-          ' ' +
-          result.zip_code +
-          ', ' +
-          result.country_code;
-        location.latitude = result.latitude;
-        location.longitude = result.longitude;
-
-        return location;
-      });
+    return this.httpClient.get<IResponseIp>('https://ipv4.myexternalip.com/json')
+      .subscribe(
+        (resp1: IResponseIp) => {
+          this.httpClient.get<IResponseFreeGeoIp>(`https://freegeoip.net/json/${resp1.ip}`)
+            .subscribe(
+              (resp2: IResponseFreeGeoIp) => {
+                const location = new Location();
+                location.address =
+                  `${resp2.city}, ${resp2.region_code} ${resp2.zip_code}, ${resp2.country_code}`;
+                location.latitude = resp2.latitude;
+                location.longitude = resp2.longitude;
+                this.mapSrv.map.panTo([location.latitude, location.longitude]);
+              },
+              (error) => {
+                throw new Error(error);
+              },
+            );
+        },
+        (error) => {
+          throw new Error(error);
+        },
+      );
   }
 }

--- a/public_src/services/map.service.ts
+++ b/public_src/services/map.service.ts
@@ -1,5 +1,5 @@
 import { EventEmitter, Injectable } from '@angular/core';
-import { Http } from '@angular/http';
+import { HttpClient } from '@angular/common/http';
 
 import { ConfService } from './conf.service';
 import { LoadService } from './load.service';
@@ -75,7 +75,7 @@ export class MapService {
 
   constructor(
     private confSrv: ConfService,
-    private http: Http,
+    private httpClient: HttpClient,
     private loadSrv: LoadService,
     private storageSrv: StorageService,
   ) {
@@ -372,30 +372,23 @@ export class MapService {
   }
 
   /**
-   *
-   * @param requestBody
-   * @param options
+   * @param res
    */
-  public renderData(requestBody: any, options: any): void {
-    this.http
-      .post('https://overpass-api.de/api/interpreter', requestBody, options)
-      .map((res) => res.json())
-      .subscribe((result) => {
-        const transformed = this.osmtogeojson(result);
-        this.ptLayer = L.geoJSON(transformed, {
-          onEachFeature: (feature, layer) => {
-            this.enableDrag(feature, layer);
-          },
-          pointToLayer: (feature, latlng) => {
-            return this.stylePoint(feature, latlng);
-          },
-          style: (feature) => {
-            return this.styleFeature(feature);
-          },
-        });
-        this.ptLayer.addTo(this.map);
-        this.loadSrv.hide();
-      });
+  public renderData(res: any): void {
+    const transformed = this.osmtogeojson(res);
+    this.ptLayer = L.geoJSON(transformed, {
+      onEachFeature: (feature, layer) => {
+        this.enableDrag(feature, layer);
+      },
+      pointToLayer: (feature, latlng) => {
+        return this.stylePoint(feature, latlng);
+      },
+      style: (feature) => {
+        return this.styleFeature(feature);
+      },
+    });
+    this.ptLayer.addTo(this.map);
+    this.loadSrv.hide();
   }
 
   /**

--- a/public_src/services/process.service.ts
+++ b/public_src/services/process.service.ts
@@ -1,4 +1,5 @@
 import { EventEmitter, Injectable } from '@angular/core';
+import { NgRedux } from '@angular-redux/store';
 import { Subject } from 'rxjs/Subject';
 
 import * as L from 'leaflet';
@@ -7,10 +8,11 @@ import { LoadService } from './load.service';
 import { MapService } from './map.service';
 import { StorageService } from './storage.service';
 
-import { IOsmEntity } from '../core/osmEntity.interface';
+import { IOsmElement } from '../core/osmElement.interface';
 import { IPtRelation } from '../core/ptRelation.interface';
 import { IPtStop } from '../core/ptStop.interface';
-import { NgRedux } from '@angular-redux/store';
+import { IOverpassResponse } from '../core/overpassResponse.interface';
+
 import { IAppState } from '../store/model';
 import { AppActions } from '../store/app/actions';
 
@@ -117,7 +119,7 @@ export class ProcessService {
    *
    * @param response
    */
-  public processResponse(response: object): void {
+  public processResponse(response: IOverpassResponse): void {
     const responseId = this.getResponseId();
     const transformedGeojson = this.mapSrv.osmtogeojson(response);
     this.storageSrv.localJsonStorage.set(responseId, response);
@@ -541,7 +543,7 @@ export class ProcessService {
    * Zooms to the input element (point position or relation geometry).
    * @param element
    */
-  public zoomToElement(element: IOsmEntity): void {
+  public zoomToElement(element: IOsmElement): void {
     if (element.type === 'node') {
       if (!element['lat'] || !element['lon']) {
         return alert(

--- a/public_src/store/app/actions.ts
+++ b/public_src/store/app/actions.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
+import { dispatch, NgRedux } from '@angular-redux/store';
 import { Action } from 'redux';
 import { IAppState } from '../model';
-import { dispatch, NgRedux } from '@angular-redux/store';
 
 @Injectable()
 export class AppActions {


### PR DESCRIPTION
- rename app Interfaces (OSMEntity to OSMElement - elements are returned from Overpass)
- refactor geocoding services by moving map related logic inside the service from component
- fix function to render all data from the request data window
- fix broken queries due to latest Overpass API changes (missing required semicolons)
- create file "responses.interfaces" with interfaces for few response types and describe response objects in the httpClient requests
- add better error handling (throw error where it is appropriate and see problems logged on the Sentry)
- reorder imports